### PR TITLE
Change: Don't depend on deprecated dash-functional

### DIFF
--- a/org-sidebar.el
+++ b/org-sidebar.el
@@ -3,7 +3,7 @@
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; URL: https://github.com/alphapapa/org-sidebar
 ;; Version: 0.4-pre
-;; Package-Requires: ((emacs "26.1") (s "1.10.0") (dash "2.13") (dash-functional "1.2.0") (org "9.0") (org-ql "0.2") (org-super-agenda "1.0"))
+;; Package-Requires: ((emacs "26.1") (s "1.10.0") (dash "2.18") (org "9.0") (org-ql "0.2") (org-super-agenda "1.0"))
 ;; Keywords: hypermedia, outlines, Org, agenda
 
 ;;; Commentary:
@@ -67,7 +67,6 @@
 (require 'subr-x)
 
 (require 'dash)
-(require 'dash-functional)
 (require 's)
 
 (require 'org-ql)


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218